### PR TITLE
Nikolai/first commit

### DIFF
--- a/README-BACKUP.md
+++ b/README-BACKUP.md
@@ -43,7 +43,7 @@ WantedBy=multi-user.target
 
 ### Backup Script
 
-**Path:** `/root/bedrock_scripts/bedrock-world-backup.sh`
+**Path:** `/root/linux-minecraft-server/bedrock-world-backup.sh`
 
 **What it does:**
 - Sends `save hold`, `save query`, and `save resume` to the Bedrock server inside the `screen` session
@@ -57,7 +57,7 @@ WantedBy=multi-user.target
 **Path:** root's crontab
 
 ```
-0 4 * * * /root/bedrock_scripts/bedrock-world-backup.sh
+0 4 * * * /root/linux-minecraft-server/bedrock-world-backup.sh
 ```
 
 This runs the backup script daily at **4:00 AM Pacific Time**.

--- a/README-BACKUP.md
+++ b/README-BACKUP.md
@@ -1,0 +1,127 @@
+# Minecraft Bedrock Server: Backup & Screen Setup
+
+This document summarizes the setup for running the Minecraft Bedrock server inside a named `screen` session and performing nightly world backups with cron.
+
+---
+
+## 🖥️ Running Bedrock Server with `screen`
+
+### Systemd Service File
+
+The Bedrock server is managed by `systemd` and launched inside a named `screen` session (`nikolai-bedrock`) to allow console command injection for live backups.
+
+**Path:** `/etc/systemd/system/bedrock.service`
+
+```
+[Unit]
+Description=Minecraft Bedrock Server
+After=network.target
+
+[Service]
+WorkingDirectory=/root/bedrock
+ExecStart=/usr/bin/screen -DmS nikolai-bedrock /root/bedrock/bedrock_server
+ExecStop=/usr/bin/screen -S nikolai-bedrock -X quit
+Restart=on-failure
+RestartSec=10
+User=root
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Commands
+
+- Start: `sudo systemctl start bedrock`
+- Stop: `sudo systemctl stop bedrock`
+- Status: `sudo systemctl status bedrock`
+- Attach to screen: `screen -r nikolai-bedrock`
+- Detach: `Ctrl + A`, then `D`
+
+---
+
+## 💾 World Backup Setup
+
+### Backup Script
+
+**Path:** `/root/bedrock_scripts/bedrock-world-backup.sh`
+
+**What it does:**
+- Sends `save hold`, `save query`, and `save resume` to the Bedrock server inside the `screen` session
+- Archives the `worlds/` directory with a timestamp
+- Saves it to `/root/bedrock_backups`
+- Deletes backups older than 180 days
+- Logs to `/root/bedrock_logs/world_backup.log`
+
+### Cron Job
+
+**Path:** root's crontab
+
+```
+0 4 * * * /root/bedrock_scripts/bedrock-world-backup.sh
+```
+
+This runs the backup script daily at **4:00 AM Pacific Time**.
+
+### Time Zone Configuration
+
+Ensure the server is set to Pacific Time:
+
+```bash
+timedatectl set-timezone America/Los_Angeles
+```
+
+Verify with:
+
+```bash
+timedatectl
+```
+
+---
+
+## 📁 Backup Output
+
+- Backups are stored in: `/root/bedrock_backups`
+- Each file: `bedrock_backup_YYYY-MM-DD_HH-MM-SS.tar.gz`
+- Backup log: `/root/bedrock/backup.log`
+
+---
+
+## Status Check Commands:
+
+```bash
+sudo systemctl status bedrock
+```
+
+should say something like:
+
+```
+● bedrock.service - Nikolai Minecraft Bedrock Server
+     Loaded: loaded (/etc/systemd/system/bedrock.service; enabled; vendor preset: enabled)
+     Active: active (running) since Mon 2025-04-07 16:02:13 PDT; 25min ago
+   Main PID: 2879 (screen)
+      Tasks: 16 (limit: 2309)
+     Memory: 187.4M
+        CPU: 42.795s
+     CGroup: /system.slice/bedrock.service
+             ├─2879 /usr/bin/SCREEN -DmS nikolai-bedrock /root/bedrock/bedrock_server
+             └─2880 /root/bedrock/bedrock_server
+```
+
+```bash
+screen -ls | grep nikolai-bedrock
+```
+
+should say something like:
+
+```
+2879.nikolai-bedrock    (04/07/25 16:02:13)     (Detached)
+```
+
+---
+
+## ✅ Done
+
+You now have:
+- Live world backups with no downtime
+- Server running in an easily controllable screen session
+- Reliable cron scheduling in the correct time zone

--- a/README-INSTALL.md
+++ b/README-INSTALL.md
@@ -1,0 +1,37 @@
+# Deployment
+
+Ubuntu 22.04 LTS
+
+# Installation
+
+## Update and install dependencies
+```bash
+sudo apt update
+sudo apt upgrade
+sudo apt install unzip curl libcurl4 libssl3 libcrypto++8 libuuid1 libncurses5 libstdc++6 screen -y
+sudo reboot
+```
+
+## Download Bedrock Server
+
+```bash
+mkdir bedrock
+cd bedrock
+curl -o bedrock-server.zip -A "Mozilla/5.0" https://www.minecraft.net/bedrockdedicatedserver/bin-linux/bedrock-server-1.21.71.01.zip
+unzip bedrock-server.zip
+```
+
+## Create systemd service
+
+```bash
+sudo nano /etc/systemd/system/bedrock.service
+```
+
+Copy and paste the contents of `bedrock-service.txt` into the file.
+
+## Enable and start the service
+
+```bash
+sudo systemctl enable bedrock
+sudo systemctl start bedrock
+```

--- a/README-LOGROTATE.md
+++ b/README-LOGROTATE.md
@@ -10,13 +10,8 @@ This script rotates and archives the `latest.log` file from the Bedrock server.
 
 ## Usage
 
-This script is executed daily via cron:
-```bash
-/etc/cron.daily/bedrock-logrotate
-```
-
-You can also run it manually
+This script is executed daily via cron: You can also run it manually
 
 ```bash
-bash /root/bedrock_scripts/bedrock-logrotate.sh
+bash /root/linux-minecraft-server/bedrock-logrotate.sh
 ```

--- a/README-LOGROTATE.md
+++ b/README-LOGROTATE.md
@@ -1,0 +1,22 @@
+# Bedrock Server Log Rotation Script
+
+This script rotates and archives the `latest.log` file from the Bedrock server.
+
+## What it does
+
+- Moves `/root/bedrock_logs/latest.log` to `/root/bedrock_logs/archive/daily-YYYY-MM-DD.log.gz`
+- Creates a new empty `latest.log` for the server to continue logging
+- Automatically deletes archived logs older than 180 days
+
+## Usage
+
+This script is executed daily via cron:
+```bash
+/etc/cron.daily/bedrock-logrotate
+```
+
+You can also run it manually
+
+```bash
+bash /root/bedrock_scripts/bedrock-logrotate.sh
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # linux-minecraft-server
 Notes and scripts for setting up Bedrock Minecraft Server on Linux
+
+## Installation
+
+[README-INSTALL.md](README-INSTALL.md)
+
+## Backup
+
+[README-BACKUP.md](README-BACKUP.md)
+
+## Log Rotation
+
+[README-LOGROTATE.md](README-LOGROTATE.md)
+
+## ChatGPT Links on the steps
+

--- a/bedrock-logrotate.sh
+++ b/bedrock-logrotate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+LOG_DIR="/root/bedrock_logs"
+ARCHIVE_DIR="$LOG_DIR/archive"
+DATE=$(date +%F) # e.g., 2025-04-07
+
+mkdir -p "$ARCHIVE_DIR"
+
+# Move and rename the current log
+if [ -f "$LOG_DIR/latest.log" ]; then
+    mv "$LOG_DIR/latest.log" "$ARCHIVE_DIR/daily-$DATE.log"
+    gzip "$ARCHIVE_DIR/daily-$DATE.log"
+fi
+
+# Recreate empty log file for server
+touch "$LOG_DIR/latest.log"
+chown root:root "$LOG_DIR/latest.log"
+chmod 644 "$LOG_DIR/latest.log"
+
+# Clean up compressed logs older than 180 days
+find "$ARCHIVE_DIR" -type f -name "*.log.gz" -mtime +180 -delete
+

--- a/bedrock-service.txt
+++ b/bedrock-service.txt
@@ -1,0 +1,14 @@
+[Unit]
+Description=Nikolai Minecraft Bedrock Server
+After=network.target
+
+[Service]
+WorkingDirectory=/root/bedrock
+ExecStart=/usr/bin/screen -DmS nikolai-bedrock /root/bedrock/bedrock_server
+ExecStop=/usr/bin/screen -S nikolai-bedrock -X quit
+Restart=on-failure
+RestartSec=10
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/bedrock-setup-firewall.sh
+++ b/bedrock-setup-firewall.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Allow SSH so you don't lock yourself out
+ufw allow OpenSSH
+
+# Allow Minecraft Bedrock (default port is 19132 UDP)
+ufw allow 19132/udp
+
+# Optional: allow IPv6 Bedrock port (some setups use 19133/udp)
+ufw allow 19133/udp
+
+# Default policies: block incoming, allow outgoing
+ufw default deny incoming
+ufw default allow outgoing
+
+# Enable the firewall without prompting
+ufw --force enable
+
+# Display status
+ufw status verbose

--- a/bedrock-world-backup.sh
+++ b/bedrock-world-backup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# === CONFIG ===
+BEDROCK_DIR="/root/bedrock"
+BACKUP_DIR="/root/bedrock_backups"
+WORLD_NAME="worlds"
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_NAME="bedrock_backup_$TIMESTAMP.tar.gz"
+LOG_FILE="/root/bedrock_logs/world_backup.log"
+SCREEN_NAME="nikolai-bedrock"
+
+echo "[`date`] Starting Bedrock world backup..." >> "$LOG_FILE"
+
+# === CREATE BACKUP FOLDER IF NEEDED ===
+mkdir -p "$BACKUP_DIR"
+
+# === SAVE WORLD STATE ===
+echo "[`date`] Sending save hold..." >> "$LOG_FILE"
+screen -S "$SCREEN_NAME" -p 0 -X stuff "save hold$(printf \\r)"
+sleep 2
+
+echo "[`date`] Sending save query..." >> "$LOG_FILE"
+screen -S "$SCREEN_NAME" -p 0 -X stuff "save query$(printf \\r)"
+sleep 2
+
+echo "[`date`] Sending save resume..." >> "$LOG_FILE"
+screen -S "$SCREEN_NAME" -p 0 -X stuff "save resume$(printf \\r)"
+sleep 2
+
+# === CREATE BACKUP ===
+echo "[`date`] Creating backup: $BACKUP_NAME" >> "$LOG_FILE"
+tar -czf "$BACKUP_DIR/$BACKUP_NAME" -C "$BEDROCK_DIR" "$WORLD_NAME"
+
+# === CLEANUP OLD BACKUPS ===
+find "$BACKUP_DIR" -type f -name "*.tar.gz" -mtime +180 -exec rm {} \;
+
+echo "[`date`] Backup complete ✅" >> "$LOG_FILE"

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,0 +1,3 @@
+0 4 * * * /root/linux-minecraft-server/bedrock-world-backup.sh
+0 3 * * * /root/linux-minecraft-server/bedrock-logrotate.sh
+


### PR DESCRIPTION

This pull request includes comprehensive updates to the documentation and scripts for setting up and maintaining a Minecraft Bedrock server on Linux. The new code encompass installation instructions, backup procedures, log rotation, and firewall setup.

### Documentation Updates:

* [`README-BACKUP.md`](diffhunk://#diff-f3e33d15999f121836e20c5a9c4c7251b1c8485b9a6815daabb8457494b8e6cbR1-R127): Added detailed instructions for running the Minecraft Bedrock server inside a `screen` session and performing nightly world backups using cron.
* [`README-INSTALL.md`](diffhunk://#diff-a985672ab93132caad3414816915467d4d988119ac23751d6f8107efdd7d8792R1-R37): Provided step-by-step installation instructions for setting up the Bedrock server on Ubuntu 22.04 LTS, including system updates, dependency installation, and service creation.
* [`README-LOGROTATE.md`](diffhunk://#diff-473ff64cffa118c8e55deb98f35648a2f50d538b72958dc496f9de51bbb0d723R1-R17): Added a guide for rotating and archiving the server's `latest.log` file, including automatic deletion of logs older than 180 days.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R17): Linked to the new detailed README files for installation, backup, and log rotation.

### Script Additions:

* [`bedrock-logrotate.sh`](diffhunk://#diff-9d706a85f50b9a7ea18e085e05e86f417fa301e85b5073c9b9806ba1b9b1bdfdR1-R22): Script for rotating and archiving the `latest.log` file, creating a new log file, and cleaning up old logs.
* [`bedrock-world-backup.sh`](diffhunk://#diff-693e1e0fccea3dbae2b8c05db49778229cc477b47d06d8930cf1c3c2f8f91a9bR1-R37): Script for performing live backups of the Minecraft world, archiving the backups, and deleting old backups.
* [`bedrock-setup-firewall.sh`](diffhunk://#diff-136b25f507e27c0bccd92f3e278c6b99965104d0c5305c6bf973fa7a01ee5390R1-R20): Script for configuring the firewall to allow necessary ports for the Minecraft Bedrock server and SSH access.

### Configuration Files:

* [`bedrock-service.txt`](diffhunk://#diff-7e4851f3c50e6f9792b97c5189162a1b343199268378ba679e0fc1aabe630fa4R1-R14): Added the `systemd` service configuration for managing the Bedrock server inside a `screen` session.

### Cron Jobs:

* [`crontab.txt`](diffhunk://#diff-136f4436249f438a906227e6c882d5d9aac2e92c2b9b6f2f04f1115b0e5da631R1-R3): Added cron jobs for daily execution of the backup and log rotation scripts at specified times.